### PR TITLE
Improve log binary display with hexdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make image/hashicorp-vault
 
 A simple Flask web application is included to view `.out` log files under the `logs/` directory. It aggregates numbered log files per folder and provides a timeline view.
 
-Binary content within log files is detected using `charset-normalizer`. Any non-text data is shown as hexadecimal for safety.
+Binary content within log files is detected using `charset-normalizer`. Any non-text data is displayed in a hexdump style format for safety.
 
 
 ### Running

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -11,8 +11,19 @@ LOG_ROOT = Path(os.environ.get('LOG_ROOT', 'logs')).resolve()
 FILE_RE = re.compile(r"^[0-9]{8}\.out$")
 
 
+def hexdump(data: bytes) -> str:
+    """Return a hexdump style string similar to `xxd -C`."""
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i:i + 16]
+        hex_bytes = ' '.join(f"{b:02x}" for b in chunk)
+        ascii_repr = ''.join(chr(b) if 32 <= b < 127 else '.' for b in chunk)
+        lines.append(f"{i:08x}  {hex_bytes:<47}  |{ascii_repr}|")
+    return "\n".join(lines)
+
+
 def read_file_validated(path: Path) -> str:
-    """Return text from path or hex representation if not valid text."""
+    """Return text from path or a hexdump if not valid text."""
     data = path.read_bytes()
     if not data:
         return ""
@@ -22,7 +33,7 @@ def read_file_validated(path: Path) -> str:
             return best.str()
     except Exception:
         pass
-    return ' '.join(f'{b:02x}' for b in data)
+    return hexdump(data)
 
 
 def find_log_dirs():


### PR DESCRIPTION
## Summary
- show binary log files in a hexdump-style format rather than plain hex
- clarify README about hexdump output

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687d9c543d7c832c90498c484c4be13a