### PR TITLE
Add systemd installer for webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A simple Flask web application is included to view `.out` log files under the `l
 Binary content within log files is detected using `charset-normalizer`. Any non-text data is displayed in a hexdump style format for safety.
 
 
-### Running
+### Running Manually
 
 ```bash
 pip install -r requirements.txt
@@ -31,3 +31,17 @@ python webapp/app.py
 ```
 
 Then open `http://localhost:5000` in your browser.
+
+### Installing as a Service
+
+Both the Exodus DNS server and the log dashboard can be managed by
+`systemd`. Each directory contains an `install.sh` script that sets up
+the service:
+
+```bash
+sudo ./exodus/install.sh
+sudo ./webapp/install.sh
+```
+
+After running these scripts the `exodus.service` and `webapp.service`
+units will be installed and started automatically.

--- a/webapp/install.sh
+++ b/webapp/install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Ensure running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root or use sudo"
+  exit 1
+fi
+
+# -------- Install Python and dependencies --------
+apt-get update
+apt-get install -y python3 python3-pip
+pip3 install --upgrade pip
+pip3 install -r "$(dirname "$0")/../requirements.txt"
+
+# -------- Copy webapp files --------
+install_dir=/opt/webapp
+mkdir -p "$install_dir"
+cp -r "$(dirname "$0")"/*.py "$install_dir"/
+mkdir -p "$install_dir/templates"
+cp -r "$(dirname "$0")"/templates/* "$install_dir/templates/"
+
+# -------- Create systemd service --------
+cat <<SERVICE > /etc/systemd/system/webapp.service
+[Unit]
+Description=Log Dashboard Web Application
+After=network.target
+
+[Service]
+WorkingDirectory=$install_dir
+ExecStart=/usr/bin/python3 $install_dir/app.py
+Restart=on-failure
+User=nobody
+Environment=LOG_ROOT=$install_dir/logs
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+# Start and enable the service
+systemctl daemon-reexec
+systemctl daemon-reload
+systemctl enable webapp
+systemctl start webapp
+
+echo "✅ Webapp installed and running"


### PR DESCRIPTION
## Summary
- provide install script for the Flask webapp
- document installing exodus and the webapp as systemd services

## Testing
- `python3 -m py_compile webapp/app.py`
- `bash -n exodus/install.sh`
- `bash -n webapp/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d9f24d8d4832c82cc4f7a01ac1a1d