### PR TITLE
Normalize log directory case

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ make image/hashicorp-vault
 
 A simple Flask web application is included to view `.out` log files under the `logs/` directory. It aggregates numbered log files per folder and provides a timeline view.
 
+Folder names are normalized to uppercase so directories such as `at`, `aT` and
+`AT` are consolidated under `AT`. If duplicate file names exist across these
+folders their contents are shown sequentially.
+
 Binary content within log files is detected using `charset-normalizer`. Any non-text data is displayed in a hexdump style format for safety.
 
 


### PR DESCRIPTION
## Summary
- normalize folder names to uppercase when reading log files
- aggregate duplicate log files across differently-cased folders
- document log directory normalization in README

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687dbe388e28832cadab71a566ca9d6b